### PR TITLE
log -> logrus

### DIFF
--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"strconv"
 	"strings"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"os"
 	"strconv"


### PR DESCRIPTION
Use logrus for logging instead of standard log library

[_Created by Sourcegraph batch change `admin/use-logrus-in-terraform-providers`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/use-logrus-in-terraform-providers)